### PR TITLE
Avoiding multiple definitions error

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ bool answer = wildcard("*.cpp", "file.cpp");
 - Getting the library from source:
 
 ```bash
-git clone https://github.com/joaovictorjs/scheduler
+git clone https://github.com/joaovictorjs/wildest-card
 ```
 
 - Setup and compile (meson required):

--- a/include/wildcard.h
+++ b/include/wildcard.h
@@ -2,7 +2,10 @@
 // Written by:   Roman Shchekin aka QtRoS
 // Licence:      MIT https://choosealicense.com/licenses/mit/
 // Project home: https://github.com/QtRoS/wildest-card
-// Version:      v1.2
+// Version:      v1.2.1
+
+#ifndef WILDCARD_H
+#define WILDCARD_H
 
 #include <memory.h>
 #include <stdbool.h>
@@ -31,7 +34,7 @@
 #define resetStates(_pStates, _size) memset(_pStates, 0, _size)
 
 // Wildcard implementation itself.
-bool wildcard(STR_TYPE const * pattern, STR_TYPE const* input)
+inline bool wildcard(STR_TYPE const * pattern, STR_TYPE const* input)
 {
     if (!pattern || !input)
         return false;
@@ -93,3 +96,4 @@ bool wildcard(STR_TYPE const * pattern, STR_TYPE const* input)
     bool result = checkState(pCurrStates, patternLength); // Check if NFA is in accepting state.
     return result;
 }
+#endif

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('wildest-card', 'c', version: '0.0.1')
+project('wildest-card', 'c', version: '1.2.1')
 
 include = include_directories('include')
 


### PR DESCRIPTION
- git clone was linking to another project
- `wildcard` function was marked as inline, preventing multi definitions error
- header guard was added
- version was upgraded to 1.2.1